### PR TITLE
ORG Update from Upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,4 @@ all:
 	$(MAKE) heroku-18 heroku-20 VERSION=5.1.0
 	$(MAKE) heroku-18 heroku-20 VERSION=5.2.0
 	$(MAKE) heroku-18 heroku-20 VERSION=5.2.1
+	$(MAKE) heroku-18 heroku-20 VERSION=5.3.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: cedar-14 heroku-16 heroku-18
+default: heroku-18 heroku-20
 
 VERSION := 5.2.0
 ROOT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -16,7 +16,7 @@ console:
 	@echo "    bin/compile /app/ /cache/ /env/"
 	@echo
 
-	@docker run --rm -ti -v $(shell pwd):/buildpack -e "STACK=heroku-18" -w /buildpack heroku/heroku:18-build \
+	@docker run --rm -ti -v $(shell pwd):/buildpack -e "STACK=heroku-20" -w /buildpack heroku/heroku:20-build \
 		bash -c 'mkdir /app /cache /env; exec bash'
 
 # Download missing source archives to ./src/
@@ -24,25 +24,13 @@ src/jemalloc-%.tar.bz2:
 	mkdir -p $$(dirname $@)
 	curl -fsL https://github.com/jemalloc/jemalloc/releases/download/$*/jemalloc-$*.tar.bz2 -o $@
 
-.PHONY: cedar-14 heroku-16 heroku-18 docker\:pull
+.PHONY: heroku-18 heroku-20 docker\:pull
 
 # Updates the docker image to ensure we're building with the latest
 # environment.
 docker\:pull:
-	docker pull heroku/cedar:14
-	docker pull heroku/heroku:16-build
 	docker pull heroku/heroku:18-build
 	docker pull heroku/heroku:20-build
-
-# Build for cedar-14 stack
-cedar-14: src/jemalloc-$(VERSION).tar.bz2 docker\:pull
-	docker run --rm -it --volume="$(ROOT_DIR):/wrk" \
-		heroku/cedar:14 /wrk/build.sh $(VERSION) cedar-14
-
-# Build for heroku-16 stack
-heroku-16: src/jemalloc-$(VERSION).tar.bz2 docker\:pull
-	docker run --rm -it --volume="$(ROOT_DIR):/wrk" \
-		heroku/heroku:16-build /wrk/build.sh $(VERSION) heroku-16
 
 # Build for heroku-18 stack
 heroku-18: src/jemalloc-$(VERSION).tar.bz2 docker\:pull
@@ -56,14 +44,14 @@ heroku-20: src/jemalloc-$(VERSION).tar.bz2 docker\:pull
 
 # Build recent releases for all supported stacks
 all:
-	$(MAKE) cedar-14 heroku-16 heroku-18 heroku-20 VERSION=3.6.0
-	$(MAKE) cedar-14 heroku-16 heroku-18 heroku-20 VERSION=4.0.4
-	$(MAKE) cedar-14 heroku-16 heroku-18 heroku-20 VERSION=4.1.1
-	$(MAKE) cedar-14 heroku-16 heroku-18 heroku-20 VERSION=4.2.1
-	$(MAKE) cedar-14 heroku-16 heroku-18 heroku-20 VERSION=4.3.1
-	$(MAKE) cedar-14 heroku-16 heroku-18 heroku-20 VERSION=4.4.0
-	$(MAKE) cedar-14 heroku-16 heroku-18 heroku-20 VERSION=4.5.0
-	$(MAKE) cedar-14 heroku-16 heroku-18 heroku-20 VERSION=5.0.1
-	$(MAKE) cedar-14 heroku-16 heroku-18 heroku-20 VERSION=5.1.0
-	$(MAKE) cedar-14 heroku-16 heroku-18 heroku-20 VERSION=5.2.0
-	$(MAKE) cedar-14 heroku-16 heroku-18 heroku-20 VERSION=5.2.1
+	$(MAKE) heroku-18 heroku-20 VERSION=3.6.0
+	$(MAKE) heroku-18 heroku-20 VERSION=4.0.4
+	$(MAKE) heroku-18 heroku-20 VERSION=4.1.1
+	$(MAKE) heroku-18 heroku-20 VERSION=4.2.1
+	$(MAKE) heroku-18 heroku-20 VERSION=4.3.1
+	$(MAKE) heroku-18 heroku-20 VERSION=4.4.0
+	$(MAKE) heroku-18 heroku-20 VERSION=4.5.0
+	$(MAKE) heroku-18 heroku-20 VERSION=5.0.1
+	$(MAKE) heroku-18 heroku-20 VERSION=5.1.0
+	$(MAKE) heroku-18 heroku-20 VERSION=5.2.0
+	$(MAKE) heroku-18 heroku-20 VERSION=5.2.1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: heroku-18 heroku-20
+default: heroku-18 heroku-20 heroku-22
 
 VERSION := 5.2.0
 ROOT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -42,17 +42,22 @@ heroku-20: src/jemalloc-$(VERSION).tar.bz2 docker\:pull
 	docker run --rm -it --volume="$(ROOT_DIR):/wrk" \
 		heroku/heroku:20-build /wrk/build.sh $(VERSION) heroku-20
 
+# Build for heroku-22 stack
+heroku-22: src/jemalloc-$(VERSION).tar.bz2 docker\:pull
+	docker run --rm -it --volume="$(ROOT_DIR):/wrk" \
+		heroku/heroku:22-build /wrk/build.sh $(VERSION) heroku-22
+
 # Build recent releases for all supported stacks
 all:
-	$(MAKE) heroku-18 heroku-20 VERSION=3.6.0
-	$(MAKE) heroku-18 heroku-20 VERSION=4.0.4
-	$(MAKE) heroku-18 heroku-20 VERSION=4.1.1
-	$(MAKE) heroku-18 heroku-20 VERSION=4.2.1
-	$(MAKE) heroku-18 heroku-20 VERSION=4.3.1
-	$(MAKE) heroku-18 heroku-20 VERSION=4.4.0
-	$(MAKE) heroku-18 heroku-20 VERSION=4.5.0
-	$(MAKE) heroku-18 heroku-20 VERSION=5.0.1
-	$(MAKE) heroku-18 heroku-20 VERSION=5.1.0
-	$(MAKE) heroku-18 heroku-20 VERSION=5.2.0
-	$(MAKE) heroku-18 heroku-20 VERSION=5.2.1
-	$(MAKE) heroku-18 heroku-20 VERSION=5.3.0
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=3.6.0
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=4.0.4
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=4.1.1
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=4.2.1
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=4.3.1
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=4.4.0
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=4.5.0
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=5.0.1
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=5.1.0
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=5.2.0
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=5.2.1
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=5.3.0

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ heroku config:set JEMALLOC_VERSION=3.6.0
 | [5.1.0](https://github.com/jemalloc/jemalloc/releases/tag/5.1.0) | 2018-05-08 |
 | [5.2.0](https://github.com/jemalloc/jemalloc/releases/tag/5.2.0) | 2019-04-02 |
 | [5.2.1](https://github.com/jemalloc/jemalloc/releases/tag/5.2.1) | 2019-08-05 |
+| [5.3.0](https://github.com/jemalloc/jemalloc/releases/tag/5.3.0) | 2022-05-06 |
 
 The complete and most up to date list of supported versions and stacks is
 available on the [releases page.](https://github.com/gaffneyc/heroku-buildpack-jemalloc/releases)


### PR DESCRIPTION
Primarily I'd like to open up our ability to

1. Set jemalloc's version with ENV
2. Allow for the [latest jemalloc features in 5.3.0](https://github.com/jemalloc/jemalloc/releases/tag/5.3.0)